### PR TITLE
WIP use a different method to calcuate collateral ratio

### DIFF
--- a/contracts/Ledger.sol
+++ b/contracts/Ledger.sol
@@ -280,7 +280,8 @@ contract Ledger is Graceful, Owned {
     function isCustomerAccount(LedgerAccount ledgerAccount) private pure returns (bool) {
         return (
             ledgerAccount == LedgerAccount.Supply ||
-            ledgerAccount == LedgerAccount.Borrow
+            ledgerAccount == LedgerAccount.Borrow ||
+            ledgerAccount == LedgerAccount.Cash
         );
     }
 
@@ -296,6 +297,7 @@ contract Ledger is Graceful, Owned {
         uint64 interestRate = getInterestRate(asset, ledgerAccount);
 
         if (interestRate > 0) {
+            failure("DEBUG::saveBlockInterest interestRate", uint256(interestRate));
             return interestRateStorage.saveBlockInterest(uint8(ledgerAccount), asset, interestRate);
         }
 

--- a/contracts/Supplier.sol
+++ b/contracts/Supplier.sol
@@ -97,14 +97,14 @@ contract Supplier is Graceful, Owned, Ledger {
             return false;
         }
 
-        // TODO: Use collateral-adjusted balance.  If a customer has borrows, we shouldn't let them
-        // withdraw below their minimum collateral value.
+        // TODO: Disallow withdrawal whose equivalent value exceeds Borrower.getMaxBorrowAvailable(msg.sender)
         uint256 balance = getBalance(msg.sender, LedgerAccount.Supply, asset);
         if (amount > balance) {
             failure("Supplier::InsufficientBalance", uint256(asset), uint256(amount), uint256(to), uint256(balance));
             return false;
         }
 
+        failure("Debug::customerWithdraw", amount);
         debit(LedgerReason.CustomerWithdrawal, LedgerAccount.Supply, msg.sender, asset, amount);
         credit(LedgerReason.CustomerWithdrawal, LedgerAccount.Cash, msg.sender, asset, amount);
 

--- a/contracts/storage/InterestRateStorage.sol
+++ b/contracts/storage/InterestRateStorage.sol
@@ -68,6 +68,7 @@ contract InterestRateStorage is Owned, Allowed {
       */
     function saveBlockInterest(uint8 ledgerAccount, address asset, uint64 currentInterestRate) public returns (bool) {
         if (!checkAllowed()) {
+            failure("DEBUG::saveBlockInterest checkAllowed false");
             return false;
         }
 


### PR DESCRIPTION
NOTE: THIS PR is to show the alternate approach.  Tests are not yet working and I still have a bunch of debug graceful failures in the solidity contracts. 

The alternate approach:
Use cash rather than supply. Cash does not change when customer
borrows more, so the borrow limit goes down as they borrow.

max borrow available =

 (cash-equiv-balance - (borrow-equiv-balance * collateral_ratio)) / collateral_ratio

- fix bug: our collateral ratio is cash-to-loan ratio so we must divide cash by the
ratio when calculating loan amounts to deliver the desired over-collaterized loans