### PR TITLE
Return to stable builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ jobs:
       - restore_cache:
           key: deploy-to-canary
       - run: "[ -d ~/repo/canary-build ] && mv ~/repo/canary-build ~/repo/build || echo 'No existing build dir'"
-      - run: "rm -rf ~/repo/build"
       - run: "[ -f ~/repo/build/contracts/MoneyMarket.json ] && rm ~/repo/build/contracts/MoneyMarket.json || echo 'not found'"
       - run: "[ -f ~/repo/build/contracts/InterestRateStorage.json ] && rm ~/repo/build/contracts/InterestRateStorage.json || echo 'not found'"
       - run: RINKEBY_PRIVATE_KEY="$CANARY_PRIVATE_KEY" ./node_modules/truffle/build/cli.bundled.js deploy --network rinkeby
@@ -89,7 +88,6 @@ jobs:
       - restore_cache:
           key: deploy-to-alpha
       - run: "[ -d ~/repo/alpha-build ] && mv ~/repo/alpha-build ~/repo/build || echo 'No existing build dir'"
-      - run: "rm -rf ~/repo/build"
       - run: "[ -f ~/repo/build/contracts/MoneyMarket.json ] && rm ~/repo/build/contracts/MoneyMarket.json || echo 'not found'"
       - run: "[ -f ~/repo/build/contracts/InterestRateStorage.json ] && rm ~/repo/build/contracts/InterestRateStorage.json || echo 'not found'"
       - run: RINKEBY_PRIVATE_KEY="$ALPHA_PRIVATE_KEY" ./node_modules/truffle/build/cli.bundled.js deploy --network rinkeby


### PR DESCRIPTION
This patch removes a line in our config where we purposefully forget about previous builds to ensure a clean from scratch deploy. This was to facilitate our improved collateral system and cleaned up migrations. Once that deploy is finished and stable, we should pull this PR to return to incremental deployments.