### PR TITLE
stop referring to TokenFactory in address recorder

### DIFF
--- a/addresses.js
+++ b/addresses.js
@@ -58,7 +58,6 @@ module.exports = async function(callback) {
       "ledger_storage": ledgerStorage.address,
       "money_market": moneyMarket.address,
       "price_oracle": priceOracle.address,
-      "token_factory": tokenFactoryAddress,
       "token_store": tokenStore.address,
       "tokens": tokens,
       "wallet_factory": walletFactory.address,


### PR DESCRIPTION
eliminates error:
`(node:98) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): ReferenceError: tokenFactoryAddress is not defined
(node:98) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.`