### PR TITLE
Added in saving of both Supply and Borrow interest on any action

### DIFF
--- a/contracts/Borrower.sol
+++ b/contracts/Borrower.sol
@@ -75,7 +75,12 @@ contract Borrower is Graceful, Owned, CollateralCalculator {
         }
 
         if (!saveBlockInterest(asset, LedgerAccount.Borrow)) {
-            failure("Borrower::FailedToSaveBlockInterest", uint256(asset), uint256(LedgerAccount.Borrow));
+            failure("Borrower::FailedToSaveBorrowBlockInterest", uint256(asset), uint256(LedgerAccount.Borrow));
+            return false;
+        }
+
+        if (!saveBlockInterest(asset, LedgerAccount.Supply)) {
+            failure("Borrower::FailedToSaveSupplyBlockInterest", uint256(asset), uint256(LedgerAccount.Supply));
             return false;
         }
 
@@ -110,7 +115,12 @@ contract Borrower is Graceful, Owned, CollateralCalculator {
         }
 
         if (!saveBlockInterest(asset, LedgerAccount.Borrow)) {
-            failure("Borrower::FailedToSaveBlockInterest", uint256(asset), uint256(LedgerAccount.Borrow));
+            failure("Borrower::FailedToSaveBorrowBlockInterest", uint256(asset), uint256(LedgerAccount.Borrow));
+            return false;
+        }
+
+        if (!saveBlockInterest(asset, LedgerAccount.Supply)) {
+            failure("Borrower::FailedToSaveSupplyBlockInterest", uint256(asset), uint256(LedgerAccount.Supply));
             return false;
         }
 

--- a/contracts/Supplier.sol
+++ b/contracts/Supplier.sol
@@ -56,7 +56,12 @@ contract Supplier is Graceful, Owned, CollateralCalculator {
         }
 
         if (!saveBlockInterest(asset, LedgerAccount.Supply)) {
-            failure("Supplier::FailedToSaveBlockInterest", uint256(asset), uint256(LedgerAccount.Supply));
+            failure("Supplier::FailedToSaveSupplyBlockInterest", uint256(asset), uint256(LedgerAccount.Supply));
+            return false;
+        }
+
+        if (!saveBlockInterest(asset, LedgerAccount.Borrow)) {
+            failure("Supplier::FailedToSaveBorrowBlockInterest", uint256(asset), uint256(LedgerAccount.Borrow));
             return false;
         }
 
@@ -98,7 +103,12 @@ contract Supplier is Graceful, Owned, CollateralCalculator {
         }
 
         if (!saveBlockInterest(asset, LedgerAccount.Supply)) {
-            failure("Supplier::FailedToSaveBlockInterest", uint256(asset), uint256(LedgerAccount.Supply));
+            failure("Supplier::FailedToSaveSupplyBlockInterest", uint256(asset), uint256(LedgerAccount.Supply));
+            return false;
+        }
+
+        if (!saveBlockInterest(asset, LedgerAccount.Borrow)) {
+            failure("Supplier::FailedToSaveBorrowBlockInterest", uint256(asset), uint256(LedgerAccount.Borrow));
             return false;
         }
 


### PR DESCRIPTION
Saves both Supply and Borrow interest rates on: Supply, Withdraw, Borrow and Payborrow. This also ensures that we emit the InterestRateUpdate events for both ledgers on any action as well.